### PR TITLE
isotree 0.5.24 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-    - https://staging.continuum.io/prefect/fs/tsl_robin_map-feedstock/pr1/194df66

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 upload_channels:
   - sfe1ed40
+
+channels:
+    - https://staging.continuum.io/prefect/fs/tsl_robin_map-feedstock/pr1/194df66

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+blas_impl:
+  - openblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,9 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
+  missing_dso_whitelist:
+    - '*/libc++.1.dylib'  # [osx]
+    - '*/libomp.dylib'    # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - wheel
     - numpy {{numpy}}
     - cython >=3.0.0
+    - tsl_robin_map
   run:
     - python
     - {{ pin_compatible('numpy') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,9 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
+  missing_dso_whitelist:
+    - '*/libc++.1.dylib'  # [osx]
+    - '*/libomp.dylib'    # [osx]
 
 requirements:
   build:
@@ -38,7 +41,6 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - pandas >=0.24.0
     - scipy
-    # - _openmp_mutex  # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - intel-openmp  # [not osx and blas_impl == 'mkl']
     - llvm-openmp   # [osx]
     - patch         # [not win]
     - m2-patch      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "isotree" %}
+{% set version = "0.5.24" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d5cb06ac442f3708aa00221f917cb5d18803c9ec256b5224a1cd08935227c9ed
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - python
+    - cython >=3.0.0
+    - setuptools
+    - wheel
+    - numpy >=1.25
+    - pip
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - isotree
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/david-cortes/isotree
+  summary: Isolation-Based Outlier Detection, Distance, and NA imputation
+  license: MIT AND BSD-2-Clause
+  license_file:
+    - LICENSE
+    - src/robinmap/LICENSE
+
+extra:
+  recipe-maintainers:
+    - boldorider4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,12 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
+  missing_dso_whitelist:
+  # libc++.1 and libomp are not found by conda-build for some reason
+  # but I did verify that they were there and that they were imported
+  # when importing isotree on a python session with conda debug
+  - '*/libc++.1.dylib'  # [osx]
+  - '*/libomp.dylib'    # [osx]
 
 requirements:
   build:
@@ -40,10 +46,10 @@ requirements:
     - scipy
     # To stop the compiler pulling in an openmp implementation itself
     # and prevent mixup with conda-forge's toolchain
-    - _openmp_mutex                   # [linux]
+    - _openmp_mutex  # [linux]
     # openmp for win: see the conda_build_config.yaml
-    - llvm-openmp   # [osx]
-    - libgomp       # [linux]
+    - llvm-openmp    # [osx]
+    - libgomp        # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,15 +15,12 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
-  missing_dso_whitelist:
-    - '*/libc++.1.dylib'  # [osx]
-    - '*/libomp.dylib'    # [osx]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    # openmp: for win, see the conda_build_config.yaml
+    # openmp for win: see the conda_build_config.yaml
     - llvm-openmp   # [osx]
     - libgomp       # [linux]
     - patch         # [not win]
@@ -41,6 +38,12 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - pandas >=0.24.0
     - scipy
+    # To stop the compiler pulling in an openmp implementation itself
+    # and prevent mixup with conda-forge's toolchain
+    - _openmp_mutex                   # [linux]
+    # openmp for win: see the conda_build_config.yaml
+    - llvm-openmp   # [osx]
+    - libgomp       # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - pandas >=0.24.0
     - scipy
+    - _openmp_mutex  # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,6 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - pandas >=0.24.0
     - scipy
-    - intel-openmp  # [not osx and blas_impl == 'mkl']
-    - llvm-openmp   # [osx]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d5cb06ac442f3708aa00221f917cb5d18803c9ec256b5224a1cd08935227c9ed
   patches:
     - patches/0001-disable-xoshiro.patch
-    # - patches/0002-add-unvendored-tsl_robin_map.patch
+    - patches/0002-add-unvendored-tsl_robin_map.patch
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d5cb06ac442f3708aa00221f917cb5d18803c9ec256b5224a1cd08935227c9ed
+  patches:
+    - patches/0001-disable-xoshiro.patch
+    # - patches/0002-add-unvendored-tsl_robin_map.patch
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
@@ -17,16 +20,24 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - intel-openmp  # [not osx and blas_impl == 'mkl']
+    - llvm-openmp   # [osx]
+    - patch         # [not win]
+    - m2-patch      # [win]
   host:
     - python
-    - cython >=3.0.0
+    - pip
     - setuptools
     - wheel
-    - numpy >=1.25
-    - pip
+    - numpy {{numpy}}
+    - cython >=3.0.0
   run:
     - python
     - {{ pin_compatible('numpy') }}
+    - pandas >=0.24.0
+    - scipy
+    - intel-openmp  # [not osx and blas_impl == 'mkl']
+    - llvm-openmp   # [osx]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,10 +39,18 @@ test:
 about:
   home: https://github.com/david-cortes/isotree
   summary: Isolation-Based Outlier Detection, Distance, and NA imputation
+  description: |
+    Fast and multi-threaded implementation of Isolation Forest (a.k.a. iForest) and variations of it such as Extended
+    Isolation Forest (EIF), Split-Criterion iForest (SCiForest), Fair-Cut Forest (FCF), Robust Random-Cut Forest
+    (RRCF), and other customizable variants, aimed at outlier/anomaly detection plus additions for imputation of
+    missing values, distance/similarity calculation between observations, and handling of categorical data.
   license: MIT AND BSD-2-Clause
   license_file:
     - LICENSE
     - src/robinmap/LICENSE
+  license_family: OTHER
+  doc_url: https://isotree.readthedocs.io
+  dev_url: https://github.com/david-cortes/isotree
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d5cb06ac442f3708aa00221f917cb5d18803c9ec256b5224a1cd08935227c9ed
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - pandas >=0.24.0
     - scipy
-    - _openmp_mutex  # [linux]
+    # - _openmp_mutex  # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,15 +15,14 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
-  missing_dso_whitelist:
-    - '*/libc++.1.dylib'  # [osx]
-    - '*/libomp.dylib'    # [osx]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    # openmp: for win, see the conda_build_config.yaml
     - llvm-openmp   # [osx]
+    - libgomp       # [linux]
     - patch         # [not win]
     - m2-patch      # [win]
   host:

--- a/recipe/patches/0001-disable-xoshiro.patch
+++ b/recipe/patches/0001-disable-xoshiro.patch
@@ -1,0 +1,34 @@
+From b40cb1d54c68ed91fedecef78bc6cf69bae62ef6 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Mon, 22 Jan 2024 21:02:41 -0600
+Subject: [PATCH] disable xoshiro
+
+https://github.com/david-cortes/isotree/blob/master/src/xoshiro.hpp 
+is license CC 1.0 and Snowflake does not want this. 
+
+We manually disable this as it seems to be optional, see 
+https://github.com/david-cortes/isotree/blob/master/CMakeLists.txt#L33-L40
+and
+https://github.com/david-cortes/isotree/blob/master/setup.py#L333.
+
+---
+ setup.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index c96cb4f..9b14e00 100644
+--- a/setup.py
++++ b/setup.py
+@@ -330,8 +330,7 @@ setup(
+                                 include_dirs=[np.get_include(), ".", "./src"],
+                                 language="c++",
+                                 install_requires = ["numpy", "pandas>=0.24.0", "cython", "scipy"],
+-                                define_macros = [("_USE_XOSHIRO", None),
+-                                                 ("NDEBUG", None),
++                                define_macros = [("NDEBUG", None),
+                                                  ("_FOR_PYTHON", None),
+                                                  ("CYTHON_EXTERN_C", 'extern "C"'),
+                                                  ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
+-- 
+2.39.1
+

--- a/recipe/patches/0002-add-unvendored-tsl_robin_map.patch
+++ b/recipe/patches/0002-add-unvendored-tsl_robin_map.patch
@@ -1,0 +1,38 @@
+From 0016308364d317b54413bfee9653f48372249916 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Mon, 22 Jan 2024 21:17:31 -0600
+Subject: [PATCH] add unvendored tsl_robin_map
+
+There is an embedded version of https://github.com/Tessil/robin-map/tree/d37a41003bfbc7e12e34601f93c18ca2ff6d7c07
+that is used by default. 
+
+https://github.com/david-cortes/isotree/blob/master/setup.py#L73-L73. 
+
+We unvendor it.
+
+See also conda-forge/tsl_robin_map-feedstock.
+
+We need to compile isotree with -D_USE_SYSTEM_ROBIN as shown in
+https://github.com/david-cortes/isotree/blob/master/CMakeLists.txt#L117.
+
+---
+ setup.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 9b14e00..372d631 100644
+--- a/setup.py
++++ b/setup.py
+@@ -330,7 +330,8 @@ setup(
+                                 include_dirs=[np.get_include(), ".", "./src"],
+                                 language="c++",
+                                 install_requires = ["numpy", "pandas>=0.24.0", "cython", "scipy"],
+-                                define_macros = [("NDEBUG", None),
++                                define_macros = [("_USE_SYSTEM_ROBIN", None),
++                                                 ("NDEBUG", None),
+                                                  ("_FOR_PYTHON", None),
+                                                  ("CYTHON_EXTERN_C", 'extern "C"'),
+                                                  ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
+-- 
+2.39.1
+


### PR DESCRIPTION
isotree 0.5.24 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3505] 
- https://github.com/david-cortes/isotree
- pypi: https://pypi.org/project/isotree/

### Depends on:

- AnacondaRecipes/tsl_robin_map-feedstock#1

### Explanation of changes:

- new package, grayskull recipe
- add dependency on OpenMP
- disable xoshiro (license CC 1.0)
- add unvendored tsl_robin_map


[PKG-3505]: https://anaconda.atlassian.net/browse/PKG-3505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ